### PR TITLE
Homework4

### DIFF
--- a/inference/kubernetes_manifests/README.md
+++ b/inference/kubernetes_manifests/README.md
@@ -1,14 +1,44 @@
+# ML in Production. Homework 4
 
-//kubectl installed
-//google cloud kit installed
-gcloud container clusters get-credentials cluster-1 --zone us-central1-c --project helical-clock-316811 --verbosity=debug
-kubectl cluster-info
-cd inference
-kubectl apply -f kubernetes_manifests/online-inference-pod.yaml
+## 1. Развернуть кластер Kubernetes
+Сервис: https://cloud.google.com/kubernetes-engine
+Убедитесь, с кластер поднялся: `kubectl cluster-info`
+
+## 2. Простой pod manifest
+Предварительно запушить docker image в Docker Hub: см `online_inference/README.md`
+Deploy: `kubectl apply -f kubernetes_manifests/online-inference-pod.yaml`
+В манифесте прописаны requests/limits:
+`requests` - прописывается, чтобы Kubernetes определил исходя из доступных ресурсов, на какой хост поместить pod,
+чтобы не деплоить приложение на хост с недостаточным кол-вом ресурсов.
+А также чтобы после выключения хоста под с прописанными ресурсами гарантированно переехал на новый хост.
+`limits` - пороговые максимальные значения, в случае превышения этих значений K8s начнет
+ограничивать (по CPU) или перезапускать контейнер (если по RAM).
+
+## 3. Liveness & Readiness
+Deploy: `kubectl apply -f kubernetes_manifests/online-inference-pod-probes.yaml`
+Если добавить 30 sec sleep при старте приложения за счет readiness настройки k8s не помечает контейнер как Ready сразу же,
+пока helth-check не прошел успешно (спустя 30 сек).
+liveness проба проверяет приложение периодически, пока контейнер запущен - и если возникнут какие-то проблемы,
+то K8s пометит контейнер как не Ready и запросы прекратят приниматься.
+
+## 4. Replicaset
+Deploy: `kubectl apply -f kubernetes_manifests/online-inference-replicaset.yaml`
+При изменении версии докер образа и увеличении кол-ва реплик - добавляются новые поды с новой версией докер образа,
+при этом старые йоды продолжают работать. Но если удалить один из старых подов,
+ReplicaSet дополнит подами с новой версией докер образа до сконфигурированного кол-ва реплик.
+При изменении версии докер образа и уменьшении кол-ва реплик - удаляются поды до нужного кол-ва.
+При этом у меня было 2 пода V2 и 4 пода  V3, и когда я изменила версию на V2 и уменьшила replicas до 3 - осталось 2 пода V2, 1 под версии V3.
+
+## 5. Deployment strategy
+Deploy: `kubectl apply -f kubernetes_manifests/online-inference-deployment-blue-green.yaml`
+deployment-blue-green: Если поставить maxUnavailable=0, maxSurge=кол-ву реплик (8),
+то сначала поднимутся все поды с новой версией образа, а потом остановятся старые поды.
+Deploy: `kubectl apply -f kubernetes_manifests/online-inference-deployment-rolling-update.yaml`
+deployment-rolling-update: к примеру выставить maxUnavailable=2, maxSurge=4 (<кол-ва реплик),
+то обновление будет происходить плавно, в какой-то момент времени будут и старые и новые приложения.
+
+-------
+Полезные команды:
 kubectl port-forward pod/fastapi-ml 8000:8000
-///
-docker build -t marinazav/online_inference:v2 .
-docker run -p 8000:8000 marinazav/online_inference:v2
-docker push marinazav/online_inference:v2
-///
-kubectl apply -f kubernetes_manifests/online-inference-pod-probes.yaml
+kubectl get pods -o wide
+kubectl get services

--- a/inference/kubernetes_manifests/README.md
+++ b/inference/kubernetes_manifests/README.md
@@ -13,6 +13,7 @@ Deploy: `kubectl apply -f kubernetes_manifests/online-inference-pod.yaml`
 А также чтобы после выключения хоста под с прописанными ресурсами гарантированно переехал на новый хост.
 `limits` - пороговые максимальные значения, в случае превышения этих значений K8s начнет
 ограничивать (по CPU) или перезапускать контейнер (если по RAM).
+(См скриншот в PR)
 
 ## 3. Liveness & Readiness
 Deploy: `kubectl apply -f kubernetes_manifests/online-inference-pod-probes.yaml`
@@ -20,6 +21,7 @@ Deploy: `kubectl apply -f kubernetes_manifests/online-inference-pod-probes.yaml`
 пока helth-check не прошел успешно (спустя 30 сек).
 liveness проба проверяет приложение периодически, пока контейнер запущен - и если возникнут какие-то проблемы,
 то K8s пометит контейнер как не Ready и запросы прекратят приниматься.
+(См скриншот в PR)
 
 ## 4. Replicaset
 Deploy: `kubectl apply -f kubernetes_manifests/online-inference-replicaset.yaml`
@@ -33,6 +35,7 @@ ReplicaSet дополнит подами с новой версией докер
 Deploy: `kubectl apply -f kubernetes_manifests/online-inference-deployment-blue-green.yaml`
 deployment-blue-green: Если поставить maxUnavailable=0, maxSurge=кол-ву реплик (8),
 то сначала поднимутся все поды с новой версией образа, а потом остановятся старые поды.
+(См скриншот в PR)
 Deploy: `kubectl apply -f kubernetes_manifests/online-inference-deployment-rolling-update.yaml`
 deployment-rolling-update: к примеру выставить maxUnavailable=2, maxSurge=4 (<кол-ва реплик),
 то обновление будет происходить плавно, в какой-то момент времени будут и старые и новые приложения.

--- a/inference/kubernetes_manifests/README.md
+++ b/inference/kubernetes_manifests/README.md
@@ -1,0 +1,13 @@
+//kubectl installed
+//google cloud kit installed
+gcloud container clusters get-credentials cluster-1 --zone us-central1-c --project helical-clock-316811 --verbosity=debug
+kubectl cluster-info
+cd inference
+kubectl apply -f kubernetes_manifests/online-inference-pod.yaml
+kubectl port-forward pod/fastapi-ml 8000:8000
+///
+docker build -t marinazav/online_inference:v2 .
+docker run -p 8000:8000 marinazav/online_inference:v2
+docker push marinazav/online_inference:v2
+///
+kubectl apply -f kubernetes_manifests/online-inference-pod-probes.yaml

--- a/inference/kubernetes_manifests/README.md
+++ b/inference/kubernetes_manifests/README.md
@@ -1,3 +1,4 @@
+
 //kubectl installed
 //google cloud kit installed
 gcloud container clusters get-credentials cluster-1 --zone us-central1-c --project helical-clock-316811 --verbosity=debug

--- a/inference/kubernetes_manifests/online-inference-deployment-blue-green.yaml
+++ b/inference/kubernetes_manifests/online-inference-deployment-blue-green.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fastapi-ml
+  labels:
+    app: fastapi-ml
+spec:
+  replicas: 8
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 8
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: fastapi-ml
+  template:
+    metadata:
+      name: fastapi-ml
+      labels:
+        app: fastapi-ml
+    spec:
+      containers:
+        - image: marinazav/online_inference:v2
+          imagePullPolicy: "Always"
+          name: fastapi-ml
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 3

--- a/inference/kubernetes_manifests/online-inference-deployment-rolling-update.yaml
+++ b/inference/kubernetes_manifests/online-inference-deployment-rolling-update.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fastapi-ml
+  labels:
+    app: fastapi-ml
+spec:
+  replicas: 8
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 4
+      maxUnavailable: 2
+  selector:
+    matchLabels:
+      app: fastapi-ml
+  template:
+    metadata:
+      name: fastapi-ml
+      labels:
+        app: fastapi-ml
+    spec:
+      containers:
+        - image: marinazav/online_inference:v2
+          name: fastapi-ml
+          ports:
+            - containerPort: 8000

--- a/inference/kubernetes_manifests/online-inference-pod-probes.yaml
+++ b/inference/kubernetes_manifests/online-inference-pod-probes.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fastapi-ml
+  labels:
+    app: fastapi-ml
+spec:
+  containers:
+    - image: marinazav/online_inference:v2
+      imagePullPolicy: "Always"
+      name: fastapi-ml
+      ports:
+        - containerPort: 8000
+      resources:
+        requests:
+          memory: "64Mi"
+          cpu: "500m"
+        limits:
+          memory: "512Mi"
+          cpu: "1000m"
+      readinessProbe:
+        httpGet:
+          path: /healthz
+          port: 8000
+        initialDelaySeconds: 5
+        periodSeconds: 3
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 8000
+        initialDelaySeconds: 45
+        periodSeconds: 3

--- a/inference/kubernetes_manifests/online-inference-pod.yaml
+++ b/inference/kubernetes_manifests/online-inference-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fastapi-ml
+  labels:
+    app: fastapi-ml
+spec:
+  containers:
+    - image: marinazav/online_inference:v1
+      name: fastapi-ml
+      ports:
+        - containerPort: 8000
+      resources:
+        requests:
+          memory: "64Mi"
+          cpu: "500m"
+        limits:
+          memory: "512Mi"
+          cpu: "1000m"

--- a/inference/kubernetes_manifests/online-inference-replicaset.yaml
+++ b/inference/kubernetes_manifests/online-inference-replicaset.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: fastapi-ml
+  labels:
+    app: fastapi-ml
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: fastapi-ml
+  template:
+    metadata:
+      name: fastapi-ml
+      labels:
+        app: fastapi-ml
+    spec:
+      containers:
+        - image: marinazav/online_inference:v3
+          name: fastapi-ml
+          ports:
+            - containerPort: 8000

--- a/inference/online_inference/README.md
+++ b/inference/online_inference/README.md
@@ -1,3 +1,5 @@
-docker build -t online_inference:v1 .
+docker build -t marinazav/online_inference:v1 .
 
-docker run -p 8000:8000 online_inference:v1
+docker run -p 8000:8000 marinazav/online_inference:v1
+
+docker push marinazav/online_inference:v1

--- a/inference/online_inference/src/app.py
+++ b/inference/online_inference/src/app.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import time
 from typing import List, Optional
 
 import uvicorn
@@ -37,6 +38,7 @@ def main():
 
 @app.on_event("startup")
 def load_app_model():
+    time.sleep(30)
     app_params = read_app_params("configs/app_config.yaml")
     logger.info("Start loading model")
     global model
@@ -47,6 +49,17 @@ def load_app_model():
 @app.get("/predict/", response_model=List[HeartDiseaseModelResponse])
 def predict(request: HeartDiseaseModelRequest):
     return make_predict(request.data, request.features, model)
+
+
+@app.get("/predict_new/", response_model=List[HeartDiseaseModelResponse])
+def predict(request: HeartDiseaseModelRequest):
+    # For checking new code version (new docker image)
+    return make_predict(request.data, request.features, model)
+
+
+@app.get("/healthz")
+def health() -> bool:
+    return not (model is None)
 
 
 def setup_app():


### PR DESCRIPTION
- [x] 1) Разверните kubernetes (5 баллов)
- [x] 2) Напишите простой pod manifests (4 балла)
- [x] 2а) Пропишите requests/limits (2 балл)
- [x] Добавьте liveness и readiness пробы (3 балла)
- [x] Создайте replicaset (3 балла)
- [x] Опишите деплоймент для вашего приложения (3 балла)
Итого: 20 баллов
-----------
В ДЗ используются Google Cloud Platform и kubectl.
Весь новый код расположен в папке `inference`.
Последовательно ответы на вопросы приведены в `inference/online_inference/README.md`.
Ниже приведены ответы, которые требуются в ДЗ:
2a) `requests` - прописывается, чтобы Kubernetes определил исходя из доступных ресурсов, на какой хост поместить pod,
чтобы не деплоить приложение на хост с недостаточным кол-вом ресурсов.
А также чтобы после выключения хоста под с прописанными ресурсами гарантированно переехал на новый хост.
`limits` - пороговые максимальные значения, в случае превышения этих значений K8s начнет
ограничивать (по CPU) или перезапускать контейнер (если по RAM).
(См скриншот в PR)
3) Если добавить 30 sec sleep при старте приложения за счет readiness настройки k8s не помечает контейнер как Ready сразу же,
пока helth-check не прошел успешно (спустя 30 сек).
liveness проба проверяет приложение периодически, пока контейнер запущен - и если возникнут какие-то проблемы,
то K8s пометит контейнер как не Ready и запросы прекратят приниматься.
(См скриншот в PR)
4) При изменении версии докер образа и увеличении кол-ва реплик - добавляются новые поды с новой версией докер образа,
при этом старые поды продолжают работать. Но если удалить один из старых подов,
ReplicaSet дополнит подами с новой версией докер образа до сконфигурированного кол-ва реплик.
При изменении версии докер образа и уменьшении кол-ва реплик - удаляются поды до нужного кол-ва.
При этом у меня было 2 пода V2 и 4 пода  V3, и когда я изменила версию на V2 и уменьшила replicas до 3 - осталось 2 пода V2, 1 под версии V3.
5) deployment-blue-green: Если поставить maxUnavailable=0, maxSurge=кол-ву реплик (8),
то сначала поднимутся все поды с новой версией образа, а потом остановятся старые поды.
(См скриншот в PR)
Deploy: `kubectl apply -f kubernetes_manifests/online-inference-deployment-rolling-update.yaml`
deployment-rolling-update: к примеру выставить maxUnavailable=2, maxSurge=4 (<кол-ва реплик),
то обновление будет происходить плавно, в какой-то момент времени будут и старые и новые приложения.

<img width="1675" alt="2_all_pods" src="https://user-images.githubusercontent.com/81704975/121970701-cb488400-cd7f-11eb-891e-50286562b12d.png">
<img width="1678" alt="2_fast_api_ml" src="https://user-images.githubusercontent.com/81704975/121970704-cc79b100-cd7f-11eb-8c9a-3a24a546a566.png">
<img width="1680" alt="2_pod_with_fast_api_ml" src="https://user-images.githubusercontent.com/81704975/121970705-cc79b100-cd7f-11eb-8929-fdb2fa090a38.png">
<img width="1679" alt="3_wait_to_startup" src="https://user-images.githubusercontent.com/81704975/121970706-cd124780-cd7f-11eb-909d-27847d9b1907.png">
<img width="1243" alt="4_green_blue_deployment" src="https://user-images.githubusercontent.com/81704975/121970708-cd124780-cd7f-11eb-87a0-5f270d9138c2.png">

---------
